### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@bazel/typescript": "1.7.0",
     "@jkcfg/kubernetes": "0.6.0",
     "@jkcfg/std": "0.3.2",
-    "@kubernetes/client-node": "0.11.0",
+    "@kubernetes/client-node": "0.12.3",
     "@types/fs-extra": "9.0.1",
     "@types/lodash-es": "4.17.3",
     "@types/node": "12",


### PR DESCRIPTION
To address "Prototype Pollution High Severity in node-forge@0.8.5" reported at @dpu/jkcfg-k8s@0.3.3 > @kubernetes/client-node@0.11.0 > openid-client@2.5.0 > node-jose@1.1.3 > node-forge@0.8.5
This issue was fixed in versions: 0.10.0